### PR TITLE
New value.converter.tag configuration that filters messages

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -1,7 +1,11 @@
 name: Java CI
 
-on: [push]
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  
 env:
   GRADLE_ARGS: "--info --stacktrace"
 

--- a/src/main/kotlin/dev/evo/kafka/elasticsearch/BaseConverter.kt
+++ b/src/main/kotlin/dev/evo/kafka/elasticsearch/BaseConverter.kt
@@ -2,15 +2,46 @@ package dev.evo.kafka.elasticsearch
 
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.connect.storage.Converter
+import org.apache.kafka.common.config.ConfigDef
 
 abstract class BaseConverter : Converter {
-    companion object {
-        val TAG_HEADER_KEY = "tag.header.key"
-        val VALUE_CONVERTER_TAG = "value.converter.tag"
-    }
-
+    protected lateinit var actionHeaderKey: String
     protected lateinit var tagHeaderKey: String
     protected lateinit var tagConfigValue: String;
+
+    companion object {
+        val ACTION_HEADER_KEY = "action.header.key"
+        val DEFAULT_ACTION_HEADER = "action"
+        val TAG_HEADER_KEY = "tag.header.key"
+        val VALUE_CONVERTER_TAG = "value.converter.tag"
+
+        fun baseConfigDef(): ConfigDef {
+            return ConfigDef().apply {
+                define(
+                    ACTION_HEADER_KEY,
+                    ConfigDef.Type.STRING,
+                    DEFAULT_ACTION_HEADER,
+                    ConfigDef.Importance.LOW,
+                    "Header key where action meta information will be stored."
+                )
+                define(
+                    TAG_HEADER_KEY,
+                    ConfigDef.Type.STRING,
+                    "tag",
+                    ConfigDef.Importance.LOW,
+                    "Header key where message tag will be stored."
+                )
+                define(
+                    VALUE_CONVERTER_TAG,
+                    ConfigDef.Type.STRING,
+                    "",
+                    ConfigDef.Importance.LOW,
+                    "Tag for the value converter. If specified, only actions with the same tag header will be processed by this converter. " +
+                            "You can specify different tag header name in 'tag.header.key' property."
+                )
+            }
+        }
+    }
 
     /**
      * Skip message if value.converter.tag is set in config, tag header is present and does not match config value.

--- a/src/main/kotlin/dev/evo/kafka/elasticsearch/BaseConverter.kt
+++ b/src/main/kotlin/dev/evo/kafka/elasticsearch/BaseConverter.kt
@@ -1,0 +1,31 @@
+package dev.evo.kafka.elasticsearch
+
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.connect.storage.Converter
+
+abstract class BaseConverter : Converter {
+    companion object {
+        val TAG_HEADER_KEY = "tag.header.key"
+        val VALUE_CONVERTER_TAG = "value.converter.tag"
+    }
+
+    protected lateinit var tagHeaderKey: String
+    protected lateinit var tagConfigValue: String;
+
+    /**
+     * Skip message if value.converter.tag is set in config, tag header is present and does not match config value.
+     *
+     * If not "tag" header present, message will be processed as usual. Such default behavior is safe and won't break
+     * existing messages.
+     */
+    protected fun shouldSkipMessage(headers: Headers): Boolean {
+        if (tagConfigValue.isEmpty()) {
+            return false
+        }
+        val tags = headers.headers(tagHeaderKey).map { it.value().toString(Charsets.UTF_8) }.toSet()
+        if (tags.isEmpty()) {
+            return false
+        }
+        return !tags.contains(tagConfigValue)
+    }
+}

--- a/src/main/kotlin/dev/evo/kafka/elasticsearch/JsonConverter.kt
+++ b/src/main/kotlin/dev/evo/kafka/elasticsearch/JsonConverter.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 import org.apache.kafka.common.config.AbstractConfig
-import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.common.header.Headers
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaAndValue
@@ -12,43 +11,16 @@ import org.apache.kafka.connect.errors.DataException
 
 class JsonConverter : BaseConverter() {
     private val json = Json.Default
-    private lateinit var actionHeaderKey: String
 
     class Config(props: MutableMap<String, *>) : AbstractConfig(CONFIG, props) {
         companion object {
-            val ACTION_HEADER_KEY = "action.header.key"
-
-            val CONFIG = ConfigDef().apply {
-                define(
-                    ACTION_HEADER_KEY,
-                    ConfigDef.Type.STRING,
-                    "action",
-                    ConfigDef.Importance.LOW,
-                    "Header key where action meta information will be stored."
-                )
-                define(
-                    TAG_HEADER_KEY,
-                    ConfigDef.Type.STRING,
-                    "tag",
-                    ConfigDef.Importance.LOW,
-                    "Header key where message tag will be stored."
-                )
-                define(
-                    VALUE_CONVERTER_TAG,
-                    ConfigDef.Type.STRING,
-                    "",
-                    ConfigDef.Importance.LOW,
-                    "Tag for the value converter. If specified, only actions with the same tag header will be processed by this converter. " +
-                            "You can specify different tag header name in 'tag.header.key' property."
-                )
-            }
-
+            val CONFIG = baseConfigDef()
         }
     }
 
     override fun configure(configs: MutableMap<String, *>, isKey: Boolean) {
         val config = Config(configs)
-        actionHeaderKey = config.getString(Config.ACTION_HEADER_KEY)
+        actionHeaderKey = config.getString(ACTION_HEADER_KEY)
         tagHeaderKey = config.getString(TAG_HEADER_KEY)
         tagConfigValue = config.getString(VALUE_CONVERTER_TAG)
     }

--- a/src/main/kotlin/dev/evo/kafka/elasticsearch/JsonConverter.kt
+++ b/src/main/kotlin/dev/evo/kafka/elasticsearch/JsonConverter.kt
@@ -70,14 +70,14 @@ class JsonConverter : Converter {
     /**
      * Skip message if value.converter.tag is configured and either
      * - tag header does not present
-     * - tag header present and does not match value.converter.tag
+     * - one or more tag headers present and none of them match value.converter.tag
      */
     private fun shouldSkipMessage(headers: Headers): Boolean {
         if (tagConfigValue.isEmpty()) {
             return false
         }
-        val tagValue = headers.lastHeader(tagHeaderKey)?.value()?.toString(Charsets.UTF_8)
-        return tagValue != tagConfigValue
+        val tags = headers.headers(tagHeaderKey).map { it.value().toString(Charsets.UTF_8) }.toSet()
+        return !tags.contains(tagConfigValue)
     }
 
     override fun toConnectData(topic: String, headers: Headers?, value: ByteArray?): SchemaAndValue {

--- a/src/main/kotlin/dev/evo/kafka/elasticsearch/JsonConverter.kt
+++ b/src/main/kotlin/dev/evo/kafka/elasticsearch/JsonConverter.kt
@@ -68,15 +68,19 @@ class JsonConverter : Converter {
     }
 
     /**
-     * Skip message if value.converter.tag is configured and either
-     * - tag header does not present
-     * - one or more tag headers present and none of them match value.converter.tag
+     * Skip message if value.converter.tag is set in config, tag header is present and does not match config value.
+     *
+     * If not "tag" header present, message will be processed as usual. Such default behavior is safe and won't break
+     * existing messages.
      */
     private fun shouldSkipMessage(headers: Headers): Boolean {
         if (tagConfigValue.isEmpty()) {
             return false
         }
         val tags = headers.headers(tagHeaderKey).map { it.value().toString(Charsets.UTF_8) }.toSet()
+        if (tags.isEmpty()) {
+            return false
+        }
         return !tags.contains(tagConfigValue)
     }
 

--- a/src/main/kotlin/dev/evo/kafka/elasticsearch/ProtobufConverter.kt
+++ b/src/main/kotlin/dev/evo/kafka/elasticsearch/ProtobufConverter.kt
@@ -15,46 +15,19 @@ import org.apache.kafka.connect.data.SchemaAndValue
 import org.apache.kafka.connect.errors.DataException
 
 class ProtobufConverter : BaseConverter() {
-    private var actionHeaderKey: String = Config.DEFAULT_ACTION_HEADER
     private val serializer = ProtobufSerializer()
     private val deserializer = ProtobufDeserializer()
 
-    class Config(props: MutableMap<String, *>) :
-            AbstractConfig(CONFIG, props)
-    {
+    class Config(props: MutableMap<String, *>) : AbstractConfig(CONFIG, props) {
         companion object {
             val PROTOBUF_CLASS = "protobuf.class"
-            val ACTION_HEADER_KEY = "action.header.key"
-            val DEFAULT_ACTION_HEADER = "action"
 
-            val CONFIG = ConfigDef().apply {
+            val CONFIG = baseConfigDef().apply {
                 define(
                     PROTOBUF_CLASS,
                     ConfigDef.Type.CLASS,
                     ConfigDef.Importance.HIGH,
                     "The full path to the protobuf class."
-                )
-                define(
-                    ACTION_HEADER_KEY,
-                    ConfigDef.Type.STRING,
-                    DEFAULT_ACTION_HEADER,
-                    ConfigDef.Importance.LOW,
-                    "Header key where action meta information will be stored."
-                )
-                define(
-                    TAG_HEADER_KEY,
-                    ConfigDef.Type.STRING,
-                    "tag",
-                    ConfigDef.Importance.LOW,
-                    "Header key where message tag will be stored."
-                )
-                define(
-                    VALUE_CONVERTER_TAG,
-                    ConfigDef.Type.STRING,
-                    "",
-                    ConfigDef.Importance.LOW,
-                    "Tag for the value converter. If specified, only actions with the same tag header will be processed by this converter. " +
-                            "You can specify different tag header name in 'tag.header.key' property."
                 )
             }
         }
@@ -63,7 +36,7 @@ class ProtobufConverter : BaseConverter() {
     override fun configure(configs: MutableMap<String, *>, isKey: Boolean) {
         val config = Config(configs)
 
-        actionHeaderKey = config.getString(Config.ACTION_HEADER_KEY)
+        actionHeaderKey = config.getString(ACTION_HEADER_KEY)
         tagHeaderKey = config.getString(TAG_HEADER_KEY)
         tagConfigValue = config.getString(VALUE_CONVERTER_TAG)
 

--- a/src/test/kotlin/dev/evo/kafka/elasticsearch/JsonConverterTests.kt
+++ b/src/test/kotlin/dev/evo/kafka/elasticsearch/JsonConverterTests.kt
@@ -254,7 +254,7 @@ class JsonConverterTests : StringSpec({
         connectData.value() shouldBe null
     }
 
-    "skip message if no tag header" {
+    "handle message if no tag header" {
         val converter = JsonConverter().apply {
             configure(mutableMapOf<String, Any>(
                 "value.converter.tag" to "foo",
@@ -271,6 +271,15 @@ class JsonConverterTests : StringSpec({
             "<test>", headers, """{"name": "Test"}""".toByteArray()
         )
         connectData.schema() shouldBe null
-        connectData.value() shouldBe null
+        val action = connectData.value() as BulkAction
+        action shouldBe BulkAction.Index(
+            id = "123",
+            type = "_doc",
+            index = "test",
+            routing = "456",
+            source = JsonSource(buildJsonObject {
+                put("name", "Test")
+            })
+        )
     }
 })

--- a/src/test/kotlin/dev/evo/kafka/elasticsearch/JsonConverterTests.kt
+++ b/src/test/kotlin/dev/evo/kafka/elasticsearch/JsonConverterTests.kt
@@ -114,4 +114,132 @@ class JsonConverterTests : StringSpec({
             })
         )
     }
+
+    "convert message if tag header present and same" {
+        val converter = JsonConverter().apply {
+            configure(mutableMapOf<String, Any>(
+                "value.converter.tag" to "foo",
+                "tag.header.key" to "tag",
+            ), false)
+        }
+        val headers = RecordHeaders().apply {
+            add(
+                "action",
+                """{"index": {"_id": "123", "_type": "_doc", "_index": "test", "routing": "456"}}""".toByteArray()
+            )
+            add("tag", "foo".toByteArray())
+        }
+        val connectData = converter.toConnectData(
+            "<test>", headers, """{"name": "Test"}""".toByteArray()
+        )
+        connectData.schema() shouldBe null
+        val action = connectData.value() as BulkAction
+        action shouldBe BulkAction.Index(
+            id = "123",
+            type = "_doc",
+            index = "test",
+            routing = "456",
+            source = JsonSource(buildJsonObject {
+                put("name", "Test")
+            })
+        )
+    }
+
+    "convert message if value.converter.tag not configured" {
+        val converter = JsonConverter().apply {
+            configure(mutableMapOf<String, Any>(), false)
+        }
+        val headers = RecordHeaders().apply {
+            add(
+                "action",
+                """{"index": {"_id": "123", "_type": "_doc", "_index": "test", "routing": "456"}}""".toByteArray()
+            )
+            add("tag", "foo".toByteArray())
+        }
+        val connectData = converter.toConnectData(
+            "<test>", headers, """{"name": "Test"}""".toByteArray()
+        )
+        connectData.schema() shouldBe null
+        val action = connectData.value() as BulkAction
+        action shouldBe BulkAction.Index(
+            id = "123",
+            type = "_doc",
+            index = "test",
+            routing = "456",
+            source = JsonSource(buildJsonObject {
+                put("name", "Test")
+            })
+        )
+    }
+
+    "convert message if tag header present and same (custom header key)" {
+        val converter = JsonConverter().apply {
+            configure(mutableMapOf<String, Any>(
+                "value.converter.tag" to "foo",
+                "tag.header.key" to "custom-tag",
+            ), false)
+        }
+        val headers = RecordHeaders().apply {
+            add(
+                "action",
+                """{"index": {"_id": "123", "_type": "_doc", "_index": "test", "routing": "456"}}""".toByteArray()
+            )
+            add("custom-tag", "foo".toByteArray())
+        }
+        val connectData = converter.toConnectData(
+            "<test>", headers, """{"name": "Test"}""".toByteArray()
+        )
+        connectData.schema() shouldBe null
+        val action = connectData.value() as BulkAction
+        action shouldBe BulkAction.Index(
+            id = "123",
+            type = "_doc",
+            index = "test",
+            routing = "456",
+            source = JsonSource(buildJsonObject {
+                put("name", "Test")
+            })
+        )
+    }
+
+    "skip message if tag header present and not the same" {
+        val converter = JsonConverter().apply {
+            configure(mutableMapOf<String, Any>(
+                "value.converter.tag" to "foo",
+                "tag.header.key" to "tag",
+            ), false)
+        }
+        val headers = RecordHeaders().apply {
+            add(
+                "action",
+                """{"index": {"_id": "123", "_type": "_doc", "_index": "test", "routing": "456"}}""".toByteArray()
+            )
+            add("tag", "bar".toByteArray())
+        }
+        val connectData = converter.toConnectData(
+            "<test>", headers, """{"name": "Test"}""".toByteArray()
+        )
+        connectData.schema() shouldBe null
+        connectData.value() shouldBe null
+    }
+
+    "skip message if no tag header" {
+        val converter = JsonConverter().apply {
+            configure(mutableMapOf<String, Any>(
+                "value.converter.tag" to "foo",
+                "tag.header.key" to "tag",
+            ), false)
+        }
+        val headers = RecordHeaders().apply {
+            add(
+                "action",
+                """{"index": {"_id": "123", "_type": "_doc", "_index": "test", "routing": "456"}}""".toByteArray()
+            )
+        }
+        val connectData = converter.toConnectData(
+            "<test>", headers, """{"name": "Test"}""".toByteArray()
+        )
+        connectData.schema() shouldBe null
+        connectData.value() shouldBe null
+    }
 })


### PR DESCRIPTION
…st be handled/skipped based on particular value of tag header

* value.converter.tag must be string (empty string means no filtering on tag)
* tag.header.key controls which header to use as a value for value.converter.tag
* add some tests